### PR TITLE
[FIX] 버그 수정 및 enum 로직 dao 이동

### DIFF
--- a/models/userDao.js
+++ b/models/userDao.js
@@ -11,7 +11,15 @@ const getUserIdByKakaoId = async(kakaoId) => {
   return result
 }
 
-const storeKakaoUserInfo = async(kakaoId, nickname, profileImageUrl, email, birthday, genderId) => {
+const storeKakaoUserInfo = async(kakaoId, nickname, profileImageUrl, email, birthday, gender) => {
+
+  let genderId = 0;
+  const GENDER = Object.freeze({
+    male : 1,
+    female : 2,
+    other : 3
+  })
+  genderId = GENDER[gender]
 
   return await appDataSource.query(`
     INSERT INTO users (

--- a/services/userService.js
+++ b/services/userService.js
@@ -21,20 +21,13 @@ const storeKakaoUserInfo = async(kakaoUserInfo) => {
   
   const kakaoId = kakaoUserInfo.id;
   const { email, birthday, gender } = kakaoUserInfo.kakao_account;
-  const { nickname, profileImageUrl } = kakaoUserInfo.kakao_account.profile;
-  
-  let genderId = 0;
-  const GENDER = Object.freeze({
-    male : 1,
-    female : 2,
-    other : 3
-  })
-  genderId = GENDER[gender]
-  
+  const { nickname } = kakaoUserInfo.kakao_account.profile;
+  const profileImageUrl = kakaoUserInfo.kakao_account.profile.profile_image_url;
+    
   const userId = await userDao.getUserIdByKakaoId(kakaoId);
 
   if (!userId) {
-    await userDao.storeKakaoUserInfo(kakaoId, nickname, profileImageUrl, email, birthday, genderId)
+    await userDao.storeKakaoUserInfo(kakaoId, nickname, profileImageUrl, email, birthday, gender)
   }
 };
 


### PR DESCRIPTION
- 비구조분해 할당을 적용한 코드에서 profileImageUrl과 profile_image_url 변수명이 맞지 않아 생긴 버그 수정 (userService.js)
- genderId enum 로직을 userDao로 이동하여 관리

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [X] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 버그 수정 및 enum 로직 이동

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오 서버에서 넘어온 정보 중 profile image url이 우리 DB에 저장이 안되는 버그 수정
- 비구조분해할당으로 리팩토링하는 과정에서 카카오 서버에서 넘어온 데이터와 우리 코드 내 변수명이 달라 발생한 버그입니다.
- 카멜 케이스로 작성한 변수명을 새로 만들어 값을 할당하는 방식으로 해결했습니다.

2. genderId 를 할당하는 enum로직을 userDao단으로 이동

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 리팩토링하는 과정에도 버그가 생길 수 있다는 것을 알게되었습니다.
- 작업 후 다시 테스트하는 습관을 들이겠습니다.

<br />

## :: 기타 질문 및 특이 사항
